### PR TITLE
Feature/refactor logging to use latest nodule config conventions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
         "winston-loggly": "^1.3.1"
     },
     "peerDependencies": {
-        "@globality/nodule-config": ">= 2.1.0 < 3"
+        "@globality/nodule-config": ">= 2.3.0 < 3"
     },
     "devDependencies": {
-        "@globality/nodule-config": "^2.1.0",
+        "@globality/nodule-config": "^2.3.0",
         "babel-cli": "^6.26.0",
         "babel-eslint": "^8.2.2",
         "babel-plugin-transform-async-to-generator": "^6.24.1",

--- a/src/__tests__/logger.test.js
+++ b/src/__tests__/logger.test.js
@@ -1,10 +1,10 @@
+import { clearBinding, getContainer } from '@globality/nodule-config';
 import config from '../__mocks__/config';
 import {
     addStream,
     createLogger,
     transportConsole,
     transportLoggly,
-    skip,
     omit,
 } from '../logger';
 
@@ -34,15 +34,16 @@ describe('create a new logger and transports', () => {
     });
 
     it('should skip ignorable routes', () => {
-        const ignore = skip(config);
-        const req = { originalUrl: '/healthcheck' };
-        expect(ignore(req)).toBe(true);
-    });
-
-    it('should skip ignorable routes', () => {
         const req = { authorization: 'xyz' };
         const redacted = omit(req, config.omitReqProperties);
         expect(redacted.authorization).toBe(undefined);
+    });
+
+    it('should not fail if graph is not initialized', () => {
+        clearBinding('logger');
+        const logger = getContainer('logger');
+        console.log('logger', logger);
+        logger.info('hello there');
     });
 
     it.skip('should return a writable stream for morgan to write logs to', () => {

--- a/src/__tests__/logger.test.js
+++ b/src/__tests__/logger.test.js
@@ -5,7 +5,6 @@ import {
     createLogger,
     transportConsole,
     transportLoggly,
-    omit,
 } from '../logger';
 
 describe('create a new logger and transports', () => {
@@ -33,11 +32,6 @@ describe('create a new logger and transports', () => {
         expect(consoleLoggly.client.token).toEqual('my-loggly-token');
     });
 
-    it('should skip ignorable routes', () => {
-        const req = { authorization: 'xyz' };
-        const redacted = omit(req, config.omitReqProperties);
-        expect(redacted.authorization).toBe(undefined);
-    });
 
     it('should not fail if graph is not initialized', () => {
         clearBinding('logger');

--- a/src/__tests__/logger.test.js
+++ b/src/__tests__/logger.test.js
@@ -1,8 +1,9 @@
-import { clearBinding, getContainer } from '@globality/nodule-config';
+import { clearBinding } from '@globality/nodule-config';
 import config from '../__mocks__/config';
 import {
     addStream,
     createLogger,
+    getLogger,
     transportConsole,
     transportLoggly,
 } from '../logger';
@@ -35,8 +36,7 @@ describe('create a new logger and transports', () => {
 
     it('should not fail if graph is not initialized', () => {
         clearBinding('logger');
-        const logger = getContainer('logger');
-        console.log('logger', logger);
+        const logger = getLogger();
         logger.info('hello there');
     });
 

--- a/src/__tests__/middleware.test.js
+++ b/src/__tests__/middleware.test.js
@@ -1,0 +1,14 @@
+import config from '../__mocks__/config';
+import {
+    skip,
+} from '../middleware';
+
+
+describe('create a new logger middleware', () => {
+    it('should skip ignorable routes', () => {
+        const { ignoreRouteUrls } = config;
+        const ignore = skip(ignoreRouteUrls);
+        const req = { originalUrl: '/healthcheck' };
+        expect(ignore(req)).toBe(true);
+    });
+});

--- a/src/__tests__/middleware.test.js
+++ b/src/__tests__/middleware.test.js
@@ -1,6 +1,7 @@
 import config from '../__mocks__/config';
 import {
     skip,
+    omit,
 } from '../middleware';
 
 
@@ -10,5 +11,11 @@ describe('create a new logger middleware', () => {
         const ignore = skip(ignoreRouteUrls);
         const req = { originalUrl: '/healthcheck' };
         expect(ignore(req)).toBe(true);
+    });
+
+    it('should skip ignorable routes', () => {
+        const req = { authorization: 'xyz' };
+        const redacted = omit(req, config.omitReqProperties);
+        expect(redacted.authorization).toBe(undefined);
     });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ bind('middleware.logging', () => middleware);
 
 
 export {
+    getLogger,
     Logger,
     extractLoggingProperties,
     getCleanStackTrace,

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+import { bind, setDefaults } from '@globality/nodule-config';
+
+import loggingDefaults from './defaults';
 import { Logger } from './logger';
 import { middleware } from './middleware';
 import {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { bind, setDefaults } from '@globality/nodule-config';
 
 import loggingDefaults from './defaults';
-import { Logger } from './logger';
+import { getLogger, Logger } from './logger';
 import { middleware } from './middleware';
 import {
     extractLoggingProperties,
@@ -11,7 +11,7 @@ import {
 } from './logFormatting';
 
 
-bind('logger', container => new Logger(container));
+bind('logger', () => getLogger());
 setDefaults('logger', loggingDefaults);
 
 bind('middleware.logging', () => middleware);

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,18 @@
 import { Logger } from './logger';
+import { middleware } from './middleware';
 import {
     extractLoggingProperties,
     getCleanStackTrace,
     getElapsedTime,
     getParentFunction,
 } from './logFormatting';
+
+
+bind('logger', container => new Logger(container));
+setDefaults('logger', loggingDefaults);
+
+bind('middleware.logging', () => middleware);
+
 
 export {
     Logger,

--- a/src/logger.js
+++ b/src/logger.js
@@ -124,7 +124,7 @@ class Logger {
 }
 
 function getLogger() {
-    const { logger, metadata } = getContainer();
+    const { metadata, config } = getContainer();
     const defaultLogglyOptions = {
         enabled: false,
         environment: 'dev',
@@ -132,7 +132,7 @@ function getLogger() {
         token: 'token',
     };
 
-    if (!logger && !metadata) {
+    if (!config && !metadata) {
         return createLogger(
             'testing-logger',
             'info',
@@ -140,7 +140,7 @@ function getLogger() {
         );
     }
 
-    if (!logger && metadata.testing) {
+    if (metadata.testing) {
         return createLogger(
             'testing-logger',
             'info',
@@ -148,7 +148,8 @@ function getLogger() {
         );
     }
 
-    return logger;
+    const container = getContainer();
+    return new Logger(container);
 }
 
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -3,6 +3,7 @@ import {
     Logger as WinstonLogger,
 } from 'winston';
 import 'winston-loggly'; // adds winston.transports.Loggly
+import { getContainer } from '@globality/nodule-config';
 
 import {
     extractLoggingProperties,
@@ -123,8 +124,30 @@ class Logger {
     }
 }
 
+class NoopLogger {
+    debug() {} // eslint-disable-line class-methods-use-this
+    info() {} // eslint-disable-line class-methods-use-this
+    warning() {} // eslint-disable-line class-methods-use-this
+    error() {} // eslint-disable-line class-methods-use-this
+}
+
+function getLogger() {
+    const { logger, metadata } = getContainer();
+
+    if (!logger && !metadata) {
+        return new NoopLogger();
+    }
+
+    if (!logger && metadata.testing) {
+        return new NoopLogger();
+    }
+
+    return logger();
+}
+
 
 module.exports = {
+    getLogger,
     Logger,
     transportConsole,
     transportLoggly,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -56,6 +56,7 @@ export default function middleware(req, res, next) {
 }
 
 module.exports = {
+    omit,
     skip,
     middleware,
 };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,40 @@
+import { getConfig, getContainer, getMetadata } from '@globality/nodule-config';
+
+// where morgan connects to winston
+function addStream(logger, level) {
+    return {
+        write: (message) => {
+            const logEntry = JSON.parse(message);
+            return logger.log(level, logEntry.message, logEntry);
+        },
+    };
+}
+
+
+// exclude any health or other ignorable urls
+function skip(ignoreRouteUrls) {
+    return function ignoreUrl(req) {
+        const url = req.originalUrl || req.url;
+        return ignoreRouteUrls.includes(url);
+    };
+}
+
+export default function middleware(req, res, next) {
+    const { format } = getConfig('logger.morgan');
+    const { level, ignoreRouteUrls } = getConfig('logger');
+
+    const { baseLogger } = getContainer('logger');
+
+
+    const formatFormat = json(format);
+    const options = {
+        stream: addStream(baseLogger, level),
+        skip: skip(ignoreRouteUrls),
+    };
+    return morgan(formatFormat, options)(req, res, next);
+}
+
+module.exports = {
+    skip,
+    middleware,
+}

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,5 +1,5 @@
 import { getConfig, getContainer } from '@globality/nodule-config';
-import morgan from 'morgan'; // eslint-disable-line import/no-extraneous-dependencies
+import morgan from 'morgan';
 import json from 'morgan-json';
 import { get } from 'lodash';
 import omitBy from 'lodash/omitBy';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,9 +1278,9 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"credstash@git+https://github.com/KensoDev/node-credstash.git#hotfix/credstash":
+"credstash@https://github.com/KensoDev/node-credstash.git#hotfix/credstash":
   version "1.0.1"
-  resolved "git+https://github.com/KensoDev/node-credstash.git#750a137777e64dc798d4ac398f9d991840ca7289"
+  resolved "https://github.com/KensoDev/node-credstash.git#750a137777e64dc798d4ac398f9d991840ca7289"
   dependencies:
     aes-js "0.2.2"
     async "1.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,9 +78,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@globality/nodule-config@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@globality/nodule-config/-/nodule-config-2.1.0.tgz#fca088220dd6d1e9c97f1e3c2a4a603d15ea712c"
+"@globality/nodule-config@^2.3.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@globality/nodule-config/-/nodule-config-2.5.0.tgz#2bd10a5d29628c14cc79a591438970daee95f4e5"
   dependencies:
     bottlejs "^1.7.0"
     credstash "https://github.com/KensoDev/node-credstash.git#hotfix/credstash"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,11 +3949,11 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.1.1"
 
-sax@1.1.5:
+sax@1.1.5, sax@>=0.6.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.5.tgz#1da50a8d00cdecd59405659f5ff85349fe773743"
 
-sax@>=0.6.0, sax@^1.2.4:
+sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -4452,11 +4452,11 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@3.0.0:
+uuid@3.0.0, uuid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
 
-uuid@^3.0.0, uuid@^3.1.0:
+uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
This does what I want when combined with `nodule-graphql`.

We want an abstraction that let's components include the logger in contexts where a full object graph may not be defined (e.g. unit tests).