### PR TITLE
Do not export getLogger

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.2
+current_version = 1.2.3
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-logging",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "Opinionated logging for Node projects",
     "main": "lib",
     "repository": "https://github.com/globality-corp/nodule-logging",

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,6 @@ bind('middleware.logging', () => middleware);
 
 
 export {
-    getLogger,
     Logger,
     extractLoggingProperties,
     getCleanStackTrace,


### PR DESCRIPTION
Why? `getLogger` should only be called *once* per app. Having it called as a bottle factory function ensures this. Each call to `getLogger` instantiates a separate winston instance which listens on the same event https://github.com/winstonjs/winston/blob/master/lib/winston/logger.js#L562 which in turn will create a memory leak.