### PR TITLE
GLOB-20596 gracefully handle missing req params.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.3
+current_version = 1.2.4
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-logging",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "description": "Opinionated logging for Node projects",
     "main": "lib",
     "repository": "https://github.com/globality-corp/nodule-logging",

--- a/src/__tests__/logFormatting.js
+++ b/src/__tests__/logFormatting.js
@@ -1,4 +1,9 @@
-import { extractLoggingProperties, getCleanStackTrace, getParentFunction } from '../logFormatting';
+import {
+    extractLoggingProperties,
+    getCleanStackTrace,
+    getParentFunction,
+    getElapsedTime,
+} from '../logFormatting';
 
 function b(req) { return getCleanStackTrace(req); }
 function a(req) { return b(req); }
@@ -56,11 +61,11 @@ const rulesX = [
     { path: 'sub2', name: 'number', type: 'number', subPaths: ['qx'] },
 ];
 
-describe('calculateUserStatus', () => {
+describe('logFormatting', () => {
     it('should find the right function`s names', async () => {
         const stackTrace = a(req);
         expect(stackTrace[0][0]).toEqual('b');
-        expect(stackTrace[0][1]).toEqual('/logFormatting.js:3:26');
+        expect(stackTrace[0][1]).toEqual('/logFormatting.js:8:26');
         expect(stackTrace[1][0]).toEqual('a');
     });
 
@@ -89,5 +94,11 @@ describe('calculateUserStatus', () => {
         expect(params.subUuidWithNumberValue).toEqual(undefined);
         expect(params.reStringWithNoMatch).toEqual(undefined);
         expect(params.sub2number).toEqual(undefined);
+    });
+
+    it('should handle malformed requests', () => {
+        // mock req does not have _startAt
+        const elapsedTime = getElapsedTime(req);
+        expect(elapsedTime).toEqual(null);
     });
 });

--- a/src/logFormatting.js
+++ b/src/logFormatting.js
@@ -3,8 +3,13 @@ import get from 'lodash/get';
 import flatten from 'lodash/flatten';
 
 export function getElapsedTime(req) {
-    const diff = process.hrtime(req._startAt); // eslint-disable-line no-underscore-dangle
-    return (diff[0] * 1e3) + (diff[1] * 1e-6);
+    const startAt = get(req, '_startAt');
+    if (startAt) {
+        const diff = process.hrtime(startAt);
+        return (diff[0] * 1e3) + (diff[1] * 1e-6);
+    }
+
+    return null;
 }
 
 // Get an array of arrays: [[Function-Name, Function-Address]]


### PR DESCRIPTION
Why? Without this, the logger can bork on malformed request objects causing
entire resolver subtress to fail.