### PR TITLE
disable getParentFunction and create setRequestStartAtMiddleware

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.3
+current_version = 1.2.4
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-logging",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "description": "Opinionated logging for Node projects",
     "main": "lib",
     "repository": "https://github.com/globality-corp/nodule-logging",

--- a/src/__tests__/logFormatting.js
+++ b/src/__tests__/logFormatting.js
@@ -1,9 +1,7 @@
-import { extractLoggingProperties, getCleanStackTrace, getParentFunction } from '../logFormatting';
+import { extractLoggingProperties, getCleanStackTrace } from '../logFormatting';
 
 function b(req) { return getCleanStackTrace(req); }
 function a(req) { return b(req); }
-function c(req) { return getParentFunction(req); }
-function d(req) { return c(req); }
 
 
 const uuidList = ['48df0785-dc66-408c-be85-718e5da94e10', 'b0a68c90-7f21-45e3-b694-323ec588de8c'];
@@ -62,11 +60,6 @@ describe('calculateUserStatus', () => {
         expect(stackTrace[0][0]).toEqual('b');
         expect(stackTrace[0][1]).toEqual('/logFormatting.js:3:26');
         expect(stackTrace[1][0]).toEqual('a');
-    });
-
-    it('should find the right parent name', async () => {
-        const parent = d(req);
-        expect(parent.functionName).toEqual('d');
     });
 
     it('should find the right parameters', async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,11 @@ import { bind, setDefaults } from '@globality/nodule-config';
 
 import loggingDefaults from './defaults';
 import { getLogger, Logger } from './logger';
-import { middleware } from './middleware';
+import { middleware, setRequestStartAtMiddleware } from './middleware';
 import {
     extractLoggingProperties,
     getCleanStackTrace,
     getElapsedTime,
-    getParentFunction,
 } from './logFormatting';
 
 
@@ -15,6 +14,7 @@ bind('logger', () => getLogger());
 setDefaults('logger', loggingDefaults);
 
 bind('middleware.logging', () => middleware);
+bind('middleware.setRequestStartAt', () => setRequestStartAtMiddleware);
 
 
 export {
@@ -22,5 +22,4 @@ export {
     extractLoggingProperties,
     getCleanStackTrace,
     getElapsedTime,
-    getParentFunction,
 };

--- a/src/logFormatting.js
+++ b/src/logFormatting.js
@@ -27,15 +27,6 @@ export function getCleanStackTrace(req, parentLevel = 0) {
         .slice(1 + parentLevel); // we dont want to return getCleanStackTrace
 }
 
-// Return an object of { functionName, functionAddress }
-// of the the function that called the function that called getParentFunction.
-// You can get info on other functions by changing the parentLevel parameter
-export function getParentFunction(req, parentLevel = 0) {
-    const realLevel = parentLevel + 2;
-    const [functionName, functionAddress] = get(getCleanStackTrace(req), `${realLevel}`, [null, null]);
-    return { functionName, functionAddress };
-}
-
 function isUuidList(property) {
     return property.every(anyNonNil);
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -9,7 +9,6 @@ import {
     extractLoggingProperties,
     getCleanStackTrace,
     getElapsedTime,
-    getParentFunction,
 } from './logFormatting';
 import loggingDefaults from './defaults';
 
@@ -116,8 +115,7 @@ class Logger {
 
     createLogParameters(req, message, args, autoLog) {
         const autoParameters = autoLog ? {
-            'elapsed-total-ms': getElapsedTime(req),
-            ...getParentFunction(req),
+            elapsedTotalMs: getElapsedTime(req),
             ...extractLoggingProperties(req, this.requestRules),
         } : {};
         return sortObj({ ...autoParameters, ...args, message });


### PR DESCRIPTION
1. `setRequestStartAtMiddleware`
Some of our logs uses `req._startAt` - set by morgan middleware 
However, we don't always want to enable it  - we should instead manually set `req._startAt` - with a simple middleware

2. disable `getParentFunction `
`getParentFunction ` used to log the current function. However, it's stopped working since we moved it to a separate library - the returned stack trace includes only noudle-logging models (i'm not convinced why). We should either fix it or discard it - i've failed to fix it in reasonable time - so for now - discard it.

3. Add `company-id` to morgan logs (it's just useful) - note - we should consider moving both `company-id` and `user-id` to the configuration. Another time.