### PR TITLE
Thing logger - morgan alternative

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.1
+current_version = 1.3.2
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-logging",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "Opinionated logging for Node projects",
     "main": "lib",
     "repository": "https://github.com/globality-corp/nodule-logging",
@@ -20,6 +20,8 @@
         "lodash": "^4.17.4",
         "morgan": "^1.7.0",
         "morgan-json": "^1.1.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1",
         "winston": "^2.3.0",
         "winston-loggly": "^1.3.1"
     },

--- a/src/__mocks__/config.js
+++ b/src/__mocks__/config.js
@@ -9,6 +9,7 @@ export default {
     level: 'info',
     ignoreRouteUrls: ['/api/health', '/healthcheck'],
     console: { colorize: false },
+    enableMorgan: true,
     morgan: {
         format: {
             length: ':res[content-length]',


### PR DESCRIPTION
In the past - we've used morgan (https://github.com/expressjs/morgan) alot - but our loggers are good enough too.
We can replace unusable morgan logger with thin logger (based on `on-finished ` and `on-headers ` that morgan uses too)
We still want to keep the morgan support - until we're convinced tat our solution is better.