### PR TITLE
Logger improvements

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.2
+current_version = 1.3.3
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-logging",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "Opinionated logging for Node projects",
     "main": "lib",
     "repository": "https://github.com/globality-corp/nodule-logging",

--- a/src/__tests__/logFormatting.js
+++ b/src/__tests__/logFormatting.js
@@ -13,7 +13,7 @@ const uuidList = ['48df0785-dc66-408c-be85-718e5da94e10', 'b0a68c90-7f21-45e3-b6
 
 const req = {
     string: 'string',
-    uuidList,
+    uuidList: uuidList.join(','),
     stringWithNumberValue: 0,
     sub: {
         string: '123',

--- a/src/logFormatting.js
+++ b/src/logFormatting.js
@@ -31,8 +31,12 @@ export function getCleanStackTrace(req, parentLevel = 0) {
         .slice(1 + parentLevel); // we dont want to return getCleanStackTrace
 }
 
+function isUuid(property) {
+    return typeof property === 'string' && anyNonNil(property);
+}
+
 function isUuidList(property) {
-    return property.every(anyNonNil);
+    return typeof property === 'string' && property.split(',').every(anyNonNil);
 }
 
 // Helper function to parseObject
@@ -41,8 +45,8 @@ function validatePropertyType(property, type, recursive) {
         (recursive && typeof property === 'object') ||
         (type === 'string' && typeof property === 'string') ||
         (type === 'number' && typeof property === 'number') ||
-        (type === 'uuid' && typeof property === 'string' && anyNonNil(property)) ||
-        (type === 'uuidList' && Array.isArray(property) && isUuidList(property))
+        (type === 'uuid' && isUuid(property)) ||
+        (type === 'uuidList' && isUuidList(property))
     );
 }
 
@@ -54,8 +58,8 @@ function parseObject(obj, { name, path, subPaths, type, recursive = true, ...arg
     if (property === null || !validatePropertyType(property, type, recursive)) {
         return [];
     }
-    if (type === 'uuidList') {
-        return [{ [name]: property }];
+    if (type === 'uuidList' && isUuidList(property)) {
+        return [{ [name]: property.split(',') }];
     }
     if (recursive && typeof property === 'object') {
         const nextPaths = subPaths || Object.keys(property);

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -5,7 +5,6 @@ import set from 'lodash/set';
 import morgan from 'morgan';
 import json from 'morgan-json';
 import onFinished from 'on-finished';
-import onHeaders from 'on-headers';
 
 // where morgan connects to winston
 function addStream(logger, level) {
@@ -70,13 +69,9 @@ function thinMiddleware(req, res, next) {
     const { logger } = getContainer();
     recordStartTime(req);
 
-    function logOnRequestStart () {
-        logger.info(req, 'OperationStarted', {});
-    }
     function logOnRequestEnd () {
         logger.info(req, 'OperationEnded', { statusCode: get(res, 'statusCode', 0) });
     }
-    onHeaders(res, logOnRequestStart);
     onFinished(res, logOnRequestEnd);
     next();
 }


### PR DESCRIPTION
Minor improvments
* Handle lists: We've changed the function in `nodule-graphql` the calls the log function - in the past, it passed lists as arrays (`[1,2,3]`), today - it passes them as a merged string ('1,2,3')
* Disable `OperationStarted` "thin" log - does not behave nicely with `nodule-graphql` (returns the same time as `OperationEnded`