### PR TITLE
Release 1.5.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.5.0
 commit = False
 tag = False
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@globality/nodule-logging",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Opinionated logging for Node projects",
     "main": "lib",
     "repository": "https://github.com/globality-corp/nodule-logging",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "morgan-json": "^1.1.0",
         "on-finished": "~2.3.0",
         "on-headers": "~1.0.1",
-        "node-loggly-bulk": "^1.1.0"
+        "node-loggly-bulk": "^2.2.4"
     },
     "peerDependencies": {
         "@globality/nodule-config": ">= 2.3.0 < 3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2944,6 +2944,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.18.1:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 morgan-json@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/morgan-json/-/morgan-json-1.1.0.tgz#f8c40b67b7d7e00e67b3bba94219ed276f550ff4"
@@ -3008,13 +3013,14 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-loggly-bulk@^1.1.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/node-loggly-bulk/-/node-loggly-bulk-1.2.1.tgz#1f0f7f65b0c625d8259055886d76090aa78a8ad6"
+node-loggly-bulk@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/node-loggly-bulk/-/node-loggly-bulk-2.2.4.tgz#bdd8638d97c43ecf1e1831ca98b250968fa6dee9"
+  integrity sha512-DfhtsDfkSBU6Dp1zvK+H1MgHRcA2yb4z07ctyA6uo+bNwKtv1exhohN910zcWNkdSYq1TImCq+O+3bOTuYHvmQ==
   dependencies:
     json-stringify-safe "5.0.x"
+    moment "^2.18.1"
     request ">=2.76.0 <3.0.0"
-    timespan "2.3.x"
 
 node-notifier@^5.2.1:
   version "5.3.0"
@@ -4004,10 +4010,6 @@ throat@^4.0.0:
 through@^2.3.6:
   version "2.3.8"
   resolved "http://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-timespan@2.3.x:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/timespan/-/timespan-2.3.0.tgz#4902ce040bd13d845c8f59b27e9d59bad6f39929"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
Updates node-loggly-bulk dependency

Old version was depending on an outdated / vulnerable package.